### PR TITLE
Change github url in galaxy.yml from git@ to https:// and fix path

### DIFF
--- a/galaxy.yml
+++ b/galaxy.yml
@@ -8,7 +8,7 @@ license: null
 license_file: null
 tags: null
 dependencies: {}
-repository: git@github.com:ansible-collections/ansible.vmware_rest.git
+repository: https://github.com/ansible-collections/vmware_rest.git
 documentation: null
 homepage: null
 issues: null


### PR DESCRIPTION
##### SUMMARY
Change github url in galaxy.yml from git@ to https:// and fix path

Galaxy needs to be able to resolve and refer to this url.

##### ISSUE TYPE
- Docs Pull Request

##### COMPONENT NAME
galaxy.yml