### PR TITLE
ansible-test: drop tests/sanity/requirements.txt

### DIFF
--- a/tests/sanity/requirements.txt
+++ b/tests/sanity/requirements.txt
@@ -1,4 +1,0 @@
-packaging  # needed for update-bundled and changelog
-sphinx ; python_version >= '3.5' # docs build requires python 3+
-sphinx-notfound-page ; python_version >= '3.5' # docs build requires python 3+
-straight.plugin ; python_version >= '3.5' # needed for hacking/build-ansible.py which will host changelog generation and requires python 3+


### PR DESCRIPTION
`ansible-test` does not read the file.

See: https://github.com/ansible-collections/overview/issues/43