### PR TITLE
tests: prepare refresh_examples.py integration

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/attach_cdrom.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/attach_cdrom.yaml
@@ -1,4 +1,5 @@
-- vcenter_vm_hardware_cdrom:
+- name: Attach an ISO image to a guest VM
+  vcenter_vm_hardware_cdrom:
     vm: '{{ test_vm1.value[0].vm }}'
     type: SATA
     sata:
@@ -11,7 +12,8 @@
     state: create
   register: _attach_cdrom_1
 
-- vcenter_vm_hardware_cdrom:
+- name: _Ensure idempotency
+  vcenter_vm_hardware_cdrom:
     vm: '{{ test_vm1.value[0].vm }}'
     type: SATA
     sata:

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/create_vm.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/create_vm.yaml
@@ -1,10 +1,14 @@
-- vcenter_cluster_info:
+- name: Build a list of all the clusters
+  vcenter_cluster_info:
   register: all_the_clusters
-- vcenter_datastore_info:
+- name: Build a list of all the datastores
+  vcenter_datastore_info:
   register: my_datastore_value
-- vcenter_folder_info:
+- name: Build a list of all the folders
+  vcenter_folder_info:
   register: my_folder_value
-- vcenter_cluster_info:
+- name: Retrieve details about the first cluster
+  vcenter_cluster_info:
     cluster: "{{ all_the_clusters.value[0].cluster }}"
   register: my_cluster_info
 
@@ -12,7 +16,8 @@
     rw_datastore: '{{ my_datastore_value.value|selectattr("name", "equalto", "rw_datastore")|first }}'
     my_virtual_machine_folder: '{{ my_folder_value.value|selectattr("type", "equalto", "VIRTUAL_MACHINE")|first }}'
 
-- vcenter_vm:
+- name: Create a VM
+  vcenter_vm:
     placement:
       cluster: "{{ all_the_clusters.value[0].cluster }}"
       datastore: "{{ rw_datastore.datastore }}"
@@ -25,8 +30,8 @@
       hot_add_enabled: true
       size_MiB: 1024
     state: create
-  register: create_vm
-- debug: var=create_vm
+  register: _create_vm
+- debug: var=_create_vm
 
 - register: test_vm1
   vcenter_vm_info:

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/purge_vms.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/purge_vms.yaml
@@ -1,17 +1,25 @@
-- register: existing_vms
+---
+- name: _Wait for the vcenter server
   vcenter_vm_info:
   retries: 100
   delay: 3
+  register: existing_vms
   until: existing_vms is not failed
 
-- name: Turn off the VMs
+- name: Collect the list of the existing VM
+  vcenter_vm_info:
+  register: existing_vms
+  until: existing_vms is not failed
+
+- name: Turn off the VM
   vcenter_vm_power:
     state: stop
     vm: '{{ item.vm }}'
   with_items: "{{ existing_vms.value }}"
   ignore_errors: yes
 
-- vcenter_vm:
+- name: Delete some VM
+  vcenter_vm:
     state: delete
     vm: '{{ item.vm }}'
   with_items: "{{ existing_vms.value }}"

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/sata_controller.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/sata_controller.yaml
@@ -6,7 +6,7 @@
     pci_slot_number: 34
   register: _sata_adapter_result_1
 
-- name: Create a SATA adapter at PCI slot 34 (again)
+- name: _Create a SATA adapter at PCI slot 34 (again)
   vcenter_vm_hardware_adapter_sata:
     state: create
     vm: '{{ test_vm1.value[0].vm }}'


### PR DESCRIPTION
refresh_examples.py will be used to generate the EXAMPLES blocks, this
commit prepare the integration.

Each blocks with no `name` key, or with a `name` starting with `_` will
be ignore. The same for the registers with a `_` prefix.