### PR TITLE
black: pin on version 19.10b0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,14 +9,14 @@ deps = -r{toxinidir}/requirements.txt
 install_command = pip install {opts} {packages}
 
 [testenv:black]
-deps = black
+deps =
+  black==19.10b0
 commands =
   black {toxinidir}/plugins {toxinidir}/tests
 
 [testenv:linters]
-install_command = pip install {opts} {packages}
 deps =
-  black
+  black==19.10b0
   flake8
 commands =
   black -v --check {toxinidir}/plugins {toxinidir}/tests


### PR DESCRIPTION
This to avoid surprise with the CI.