### PR TITLE
tests: rename test_vm1 variable for clarity

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/attach_cdrom.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/attach_cdrom.yaml
@@ -1,6 +1,6 @@
 - name: Attach an ISO image to a guest VM
   vcenter_vm_hardware_cdrom:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
     type: SATA
     sata:
       bus: 0
@@ -14,7 +14,7 @@
 
 - name: _Ensure idempotency
   vcenter_vm_hardware_cdrom:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
     type: SATA
     sata:
       bus: 0

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/ethernet.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/ethernet.yaml
@@ -1,7 +1,7 @@
 - name: Attach a VM to a dvswitch
   vcenter_vm_hardware_ethernet:
     state: create
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
     pci_slot_number: 4
     backing:
       type: DISTRIBUTED_PORTGROUP
@@ -12,7 +12,7 @@
 - name: _Attach a VM to a dvswitch (again)
   vcenter_vm_hardware_ethernet:
     state: create
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
     pci_slot_number: 4
     backing:
       type: DISTRIBUTED_PORTGROUP
@@ -30,8 +30,8 @@
     state: update
     nic: 4000
     start_connected: true
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
 
 - name: Collect a list of the NIC for a given VM
   vcenter_vm_hardware_ethernet_info:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/main.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/main.yaml
@@ -15,5 +15,5 @@
 - import_tasks: vm_hardware_boot.yaml
 - import_tasks: vm_power.yaml
 - vcenter_vm_info:
-    vm: '{{ test_vm1.value[0].vm }}'
-# - import_tasks: wait_for_test_vm1.yaml
+    vm: '{{ test_vm1_info.value[0].vm }}'
+# - import_tasks: wait_for_test_vm1_info.yaml

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/sata_controller.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/sata_controller.yaml
@@ -1,19 +1,19 @@
 ---
 - name: List the SATA adapter of a given VM
   vcenter_vm_hardware_adapter_sata_info:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
 
 - name: Create a SATA adapter at PCI slot 34
   vcenter_vm_hardware_adapter_sata:
     state: create
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
     pci_slot_number: 34
   register: _sata_adapter_result_1
 
 - name: _Create a SATA adapter at PCI slot 34 (again)
   vcenter_vm_hardware_adapter_sata:
     state: create
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
     pci_slot_number: 34
   register: _sata_adapter_result_2
 

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_boot.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_hardware_boot.yaml
@@ -1,10 +1,10 @@
 - name: Retrieve the boot information from the VM
   vcenter_vm_hardware_boot_info:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
 
 - name: Change a VM boot parameters
   vcenter_vm_hardware_boot:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
     efi_legacy_boot: True
     type: EFI
     state: update

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_info.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_info.yaml
@@ -1,5 +1,6 @@
 ---
-- register: test_vm1
+- name: Look up the VM called test_vm1 in the inventory
+  register: search_result
   vcenter_vm_info:
     filter_names:
     - test_vm1
@@ -8,4 +9,5 @@
 
 - name: Collect information about a specific VM
   vcenter_vm_info:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ search_result.value[0].vm }}'
+  register: test_vm1_info

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_power.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/vm_power.yaml
@@ -1,5 +1,5 @@
 - name: Turn the power of a VM on
   vcenter_vm_power:
     state: start
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
 

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/wait_for_test_vm1.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/wait_for_test_vm1.yaml
@@ -1,5 +1,5 @@
 - vcenter_vm_tools_info:
-    vm: '{{ test_vm1.value[0].vm }}'
+    vm: '{{ test_vm1_info.value[0].vm }}'
   register: vm_tools_info
   until:
   - vm_tools_info is not failed


### PR DESCRIPTION
Use `test_vm1_info` instead.