### PR TITLE
tests: use the local (ESXi) datastore

### DIFF
--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/create_vm.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/create_vm.yaml
@@ -1,9 +1,8 @@
-- debug: var=my_datastore.datastore
 - name: Create a VM
   vmware.vmware_rest.vcenter_vm:
     placement:
       cluster: "{{ my_cluster_info.id }}"
-      datastore: "{{ my_datastore.datastore }}"
+      datastore: "{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/datastore/local') }}"
       folder: "{{ my_virtual_machine_folder.folder }}"
       resource_pool: "{{ my_cluster_info.value.resource_pool }}"
     name: test_vm1
@@ -21,7 +20,7 @@
   vmware.vmware_rest.vcenter_vm:
     placement:
       cluster: "{{ my_cluster_info.id }}"
-      datastore: "{{ my_datastore.datastore }}"
+      datastore: "{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/datastore/local') }}"
       folder: "{{ my_virtual_machine_folder.folder }}"
       resource_pool: "{{ my_cluster_info.value.resource_pool }}"
     name: test_vm1
@@ -107,7 +106,7 @@
       published: true
       authentication_method: 'NONE'
     storage_backings:
-      - datastore_id: "{{ my_datastore.datastore }}"
+      - datastore_id: "{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/datastore/local') }}"
         type: 'DATASTORE'
     state: present
   register: ds_lib
@@ -179,7 +178,7 @@
       automatic_sync_enabled: false
       on_demand: true
     storage_backings:
-      - datastore_id: "{{ my_datastore.datastore }}"
+      - datastore_id: "{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/datastore/local') }}"
         type: 'DATASTORE'
   register: sub_lib
 
@@ -192,7 +191,7 @@
       automatic_sync_enabled: false
       on_demand: true
     storage_backings:
-      - datastore_id: "{{ my_datastore.datastore }}"
+      - datastore_id: "{{ lookup('vmware.vmware_rest.datastore_moid', '/my_dc/datastore/local') }}"
         type: 'DATASTORE'
   register: result
 - name: Assert the resource has not been changed

--- a/tests/integration/targets/vcenter_vm_scenario1/tasks/read_env_information.yaml
+++ b/tests/integration/targets/vcenter_vm_scenario1/tasks/read_env_information.yaml
@@ -9,21 +9,6 @@
 
 - debug: var=my_cluster_info
 
-- name: Retrieve a list of all the datastores
-  vmware.vmware_rest.vcenter_datastore_info:
-  register: my_datastores
-- debug: var=my_datastores
-
-- name: We can also use filter to limit the number of result
-  vmware.vmware_rest.vcenter_datastore_info:
-    filter_names:
-      - rw_datastore
-  register: my_datastores
-
-- name: Set my_datastore
-  set_fact:
-    my_datastore: '{{ my_datastores.value|first }}'
-
 - name: Build a list of all the folders
   vmware.vmware_rest.vcenter_folder_info:
   register: my_folders


### PR DESCRIPTION
Improve the reliability of the test by using the datastore of the ESXi.
