### PR TITLE
disable check mode for non-info modules

### DIFF
--- a/changelogs/fragments/624-disable-check-mode.yml
+++ b/changelogs/fragments/624-disable-check-mode.yml
@@ -1,0 +1,4 @@
+---
+minor_changes:
+  - Disable check mode for all non-info modules in this collection. Check mode was never supported for these modules.
+    Fixes https://github.com/ansible-collections/vmware.vmware_rest/issues/363

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,6 +33,10 @@ See [Ansible Using collections](https://docs.ansible.com/ansible/latest/user_gui
     b. Copy the contents of `config/output` to the proper places in this repo
     c. The main things to copy will be `plugins`, `tests`, and `runtime`. The other generated files probably dont need to replace the existing files
 
+6. Update check mode
+    a. The non-info modules in this collection do not support check mode. Unfortunately the generation method is not flexible enough to handle this (or updating it takes too much effort ATM).
+    b. The easiest way to do this is in a code editor like VSCode. Do a find and replace for `supports_check_mode=True` and change it to False, and exclude `*_info.py`
+
 #### (Optional) Update the `RETURN Block` of the vmware modules using the test-suite
 
 The `generate.yml` playbook will copy the old blocks to the new modules. You can refresh the blocks if you introduce a new API version.

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -178,7 +178,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_access_dcui.py
+++ b/plugins/modules/appliance_access_dcui.py
@@ -176,7 +176,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_access_shell.py
+++ b/plugins/modules/appliance_access_shell.py
@@ -198,7 +198,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_access_ssh.py
+++ b/plugins/modules/appliance_access_ssh.py
@@ -177,7 +177,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_infraprofile_configs.py
+++ b/plugins/modules/appliance_infraprofile_configs.py
@@ -268,7 +268,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_localaccounts_globalpolicy.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy.py
@@ -195,7 +195,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -248,7 +248,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking.py
+++ b/plugins/modules/appliance_networking.py
@@ -186,7 +186,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_dns_domains.py
+++ b/plugins/modules/appliance_networking_dns_domains.py
@@ -195,7 +195,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_dns_hostname.py
+++ b/plugins/modules/appliance_networking_dns_hostname.py
@@ -188,7 +188,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_dns_servers.py
+++ b/plugins/modules/appliance_networking_dns_servers.py
@@ -230,7 +230,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_firewall_inbound.py
+++ b/plugins/modules/appliance_networking_firewall_inbound.py
@@ -216,7 +216,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_interfaces_ipv4.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4.py
@@ -237,7 +237,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_interfaces_ipv6.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6.py
@@ -231,7 +231,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_noproxy.py
+++ b/plugins/modules/appliance_networking_noproxy.py
@@ -191,7 +191,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_networking_proxy.py
+++ b/plugins/modules/appliance_networking_proxy.py
@@ -270,7 +270,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -201,7 +201,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_services.py
+++ b/plugins/modules/appliance_services.py
@@ -196,7 +196,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_shutdown.py
+++ b/plugins/modules/appliance_shutdown.py
@@ -209,7 +209,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_system_globalfips.py
+++ b/plugins/modules/appliance_system_globalfips.py
@@ -168,7 +168,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_system_storage.py
+++ b/plugins/modules/appliance_system_storage.py
@@ -182,7 +182,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_system_time_timezone.py
+++ b/plugins/modules/appliance_system_time_timezone.py
@@ -177,7 +177,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_timesync.py
+++ b/plugins/modules/appliance_timesync.py
@@ -185,7 +185,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -209,7 +209,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/content_configuration.py
+++ b/plugins/modules/content_configuration.py
@@ -236,7 +236,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/content_locallibrary.py
+++ b/plugins/modules/content_locallibrary.py
@@ -1583,7 +1583,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/content_subscribedlibrary.py
+++ b/plugins/modules/content_subscribedlibrary.py
@@ -781,7 +781,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_datacenter.py
+++ b/plugins/modules/vcenter_datacenter.py
@@ -249,7 +249,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_host.py
+++ b/plugins/modules/vcenter_host.py
@@ -271,7 +271,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_ovf_libraryitem.py
+++ b/plugins/modules/vcenter_ovf_libraryitem.py
@@ -458,7 +458,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_resourcepool.py
+++ b/plugins/modules/vcenter_resourcepool.py
@@ -355,7 +355,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm.py
+++ b/plugins/modules/vcenter_vm.py
@@ -1676,7 +1676,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_guest_customization.py
+++ b/plugins/modules/vcenter_vm_guest_customization.py
@@ -534,7 +534,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_guest_filesystem_directories.py
+++ b/plugins/modules/vcenter_vm_guest_filesystem_directories.py
@@ -324,7 +324,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_guest_power.py
+++ b/plugins/modules/vcenter_vm_guest_power.py
@@ -226,7 +226,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware.py
+++ b/plugins/modules/vcenter_vm_hardware.py
@@ -304,7 +304,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata.py
@@ -248,7 +248,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi.py
@@ -283,7 +283,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_boot.py
+++ b/plugins/modules/vcenter_vm_hardware_boot.py
@@ -262,7 +262,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_boot_device.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device.py
@@ -223,7 +223,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_cdrom.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom.py
@@ -336,7 +336,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_cpu.py
+++ b/plugins/modules/vcenter_vm_hardware_cpu.py
@@ -245,7 +245,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_disk.py
+++ b/plugins/modules/vcenter_vm_hardware_disk.py
@@ -364,7 +364,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_ethernet.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet.py
@@ -433,7 +433,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_floppy.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy.py
@@ -283,7 +283,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_memory.py
+++ b/plugins/modules/vcenter_vm_hardware_memory.py
@@ -224,7 +224,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_parallel.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel.py
@@ -275,7 +275,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_hardware_serial.py
+++ b/plugins/modules/vcenter_vm_hardware_serial.py
@@ -353,7 +353,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_power.py
+++ b/plugins/modules/vcenter_vm_power.py
@@ -316,7 +316,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_storage_policy.py
+++ b/plugins/modules/vcenter_vm_storage_policy.py
@@ -234,7 +234,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_storage_policy_compliance.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance.py
@@ -188,7 +188,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_tools.py
+++ b/plugins/modules/vcenter_vm_tools.py
@@ -244,7 +244,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vm_tools_installer.py
+++ b/plugins/modules/vcenter_vm_tools_installer.py
@@ -222,7 +222,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")

--- a/plugins/modules/vcenter_vmtemplate_libraryitems.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems.py
@@ -538,7 +538,7 @@ async def main():
 
     module_args = prepare_argument_spec()
     module = AnsibleModule(
-        argument_spec=module_args, required_if=required_if, supports_check_mode=True
+        argument_spec=module_args, required_if=required_if, supports_check_mode=False
     )
     if not module.params["vcenter_hostname"]:
         module.fail_json("vcenter_hostname cannot be empty")


### PR DESCRIPTION
##### SUMMARY
Disable check mode support for all non-info modules. They never supported check mode.
Fixes https://github.com/ansible-collections/vmware.vmware_rest/issues/363

##### ISSUE TYPE
- Bugfix Pull Request