### PR TITLE
Build Ansible Docs: extra-collections instead of provide-link-targets

### DIFF
--- a/.github/workflows/docs-pr.yml
+++ b/.github/workflows/docs-pr.yml
@@ -23,6 +23,18 @@ jobs:
       artifact-name: ${{ github.event.repository.name }}_docs_${{ github.event.pull_request.head.sha }}_validate
       intersphinx-links: |
         ansible_devel:https://docs.ansible.com/ansible-core/devel/
+      provide-link-targets: |
+        ansible_collections.vmware.vmware.appliance_info_module
+        ansible_collections.vmware.vmware.cluster_info_module
+        ansible_collections.vmware.vmware.content_library_item_info_module
+        ansible_collections.vmware.vmware.esxi_host_module
+        ansible_collections.vmware.vmware.local_content_library_module
+        ansible_collections.vmware.vmware.subscribed_content_library_module
+        ansible_collections.vmware.vmware.vcsa_settings_module
+        ansible_collections.vmware.vmware.vm_portgroup_info_module
+        ansible_collections.vmware.vmware.vm_powerstate_module
+        ansible_collections.vmware.vmware.vm_resource_info_module
+        ansible_collections.vmware.vmware.moid_from_path_module
 
   build-docs:
     permissions:


### PR DESCRIPTION
##### SUMMARY
This collection refers to modules from another collection: vmware.vmware. This fails the Build Ansible Docs CI job because it doesn't know about it.

It seems that the current fix is to fake the missing references with provide-link-targets. I wonder if it wouldn't be better to make the job aware of vmware.vmware via extra-collections instead.

##### ISSUE TYPE
- Docs Pull Request
- Feature Pull Request

##### COMPONENT NAME
.github/workflows/docs-pr.yml

##### ADDITIONAL INFORMATION
#627