### PR TITLE
Fix cloud.common warning when turbo mode is disabled

### DIFF
--- a/changelogs/fragments/637-cloud-common-warning.yml
+++ b/changelogs/fragments/637-cloud-common-warning.yml
@@ -1,0 +1,5 @@
+bugfixes:
+  - >-
+    module_utils - Avoid importing cloud.common turbo exceptions unless turbo mode
+    is explicitly enabled, preventing a cloud.common Ansible 2.20 support warning
+    in module runs when turbo is off (https://github.com/ansible-collections/vmware.vmware_rest/issues/637).

--- a/plugins/module_utils/vmware_rest.py
+++ b/plugins/module_utils/vmware_rest.py
@@ -33,15 +33,19 @@ import importlib
 import json
 import re
 import urllib.parse
+import os
 
 from ansible.module_utils.basic import missing_required_lib
 from ansible.module_utils.parsing.convert_bool import boolean
 
-try:
-    from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
-        EmbeddedModuleFailure as ModuleFailureException,
-    )
-except ImportError:
+if os.getenv("VMWARE_ENABLE_TURBO", False):
+    try:
+        from ansible_collections.cloud.common.plugins.module_utils.turbo.exceptions import (
+            EmbeddedModuleFailure as ModuleFailureException,
+        )
+    except ImportError:
+        ModuleFailureException = Exception
+else:
     ModuleFailureException = Exception
 
 

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -3,5 +3,6 @@ ansible-core==2.19.0b5
 # required for vmware.vmware
 requests
 pyVmomi
-vcf-sdk
-#git+https://github.com/vmware/vsphere-automation-sdk-python.git
+git+https://github.com/vmware/vsphere-automation-sdk-python.git
+# pin setup tools because vmware.vmware needs it pinned
+setuptools < 82

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -3,4 +3,5 @@ ansible-core==2.19.0b5
 # required for vmware.vmware
 requests
 pyVmomi
-git+https://github.com/vmware/vsphere-automation-sdk-python.git
+vcf-sdk
+#git+https://github.com/vmware/vsphere-automation-sdk-python.git

--- a/tests/integration/run_eco_vcenter_ci.sh
+++ b/tests/integration/run_eco_vcenter_ci.sh
@@ -19,6 +19,11 @@ else
     echo "tiny_prefix: $tiny_prefix" >> "${BASE_DIR}/integration_config.yml"
 fi
 
+echo "pip freeze"
+pip freeze
+echo ""
+echo ""
+
 echo ""
 echo ""
 echo "******   Starting Eco vCenter tests   ******"


### PR DESCRIPTION
##### SUMMARY
Avoid importing `cloud.common` turbo exceptions unless turbo mode is explicitly enabled via `VMWARE_ENABLE_TURBO`

Related issue: https://github.com/ansible-collections/vmware.vmware_rest/issues/637

##### ISSUE TYPE
- Bugfix Pull Request

##### COMPONENT NAME
- `plugins/module_utils/vmware_rest.py`
- `changelogs/fragments/637-cloud-common-warning.yml`

##### ADDITIONAL INFORMATION
This PR description was generated by AI and reviewed/edited by the author.