### PR TITLE
Deprecate VMWARE_ENABLE_TURBO

### DIFF
--- a/changelogs/fragments/639-vmware_enable_turbo.yml
+++ b/changelogs/fragments/639-vmware_enable_turbo.yml
@@ -1,0 +1,3 @@
+deprecated_features:
+  - turbo mode and the associated environment variable ``VMWARE_ENABLE_TURBO`` are deprecated and will be removed from ``vmware.vmware_rest`` 5.0.0 
+    (https://github.com/ansible-collections/vmware.vmware_rest/pull/639).

--- a/docs/turbo_mode.md
+++ b/docs/turbo_mode.md
@@ -1,5 +1,7 @@
 # vmware.vmware_rest Turbo Mode
 
+!!! Please be aware that this is deprecated and will be removed in a future major release. !!!
+
 This collection is capable of leveraging a feature of the cloud.common collection called the "turbo server". This is basically a caching mechanism that speeds up repeated API calls. This collection has used turbo mode up until version 4.8.0. With the release of 4.8.0, turbo mode is disabled by default but can be re-enabled using an environment variable.
 
 Read more about the turbo server in the cloud.common documentation [here](https://github.com/ansible-collections/cloud.common?tab=readme-ov-file#ansible-turbo-module).

--- a/docs/turbo_mode.md
+++ b/docs/turbo_mode.md
@@ -1,6 +1,7 @@
-# vmware.vmware_rest Turbo Mode
+> [!WARNING]
+> Please be aware that Turbo Mode is deprecated and will be removed in a future major release.
 
-!!! Please be aware that this is deprecated and will be removed in a future major release. !!!
+# vmware.vmware_rest Turbo Mode
 
 This collection is capable of leveraging a feature of the cloud.common collection called the "turbo server". This is basically a caching mechanism that speeds up repeated API calls. This collection has used turbo mode up until version 4.8.0. With the release of 4.8.0, turbo mode is disabled by default but can be re-enabled using an environment variable.
 

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -186,6 +186,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_access_consolecli.py
+++ b/plugins/modules/appliance_access_consolecli.py
@@ -186,10 +186,6 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
-    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
-        module.warn(
-            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
-        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_applmgmt_info.py
+++ b/plugins/modules/appliance_health_applmgmt_info.py
@@ -163,6 +163,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_database_info.py
+++ b/plugins/modules/appliance_health_database_info.py
@@ -157,6 +157,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_databasestorage_info.py
+++ b/plugins/modules/appliance_health_databasestorage_info.py
@@ -163,6 +163,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_load_info.py
+++ b/plugins/modules/appliance_health_load_info.py
@@ -163,6 +163,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_mem_info.py
+++ b/plugins/modules/appliance_health_mem_info.py
@@ -164,6 +164,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_softwarepackages_info.py
+++ b/plugins/modules/appliance_health_softwarepackages_info.py
@@ -168,6 +168,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_storage_info.py
+++ b/plugins/modules/appliance_health_storage_info.py
@@ -163,6 +163,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_swap_info.py
+++ b/plugins/modules/appliance_health_swap_info.py
@@ -163,6 +163,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_health_system_info.py
+++ b/plugins/modules/appliance_health_system_info.py
@@ -163,6 +163,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_infraprofile_configs.py
+++ b/plugins/modules/appliance_infraprofile_configs.py
@@ -276,6 +276,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_infraprofile_configs_info.py
+++ b/plugins/modules/appliance_infraprofile_configs_info.py
@@ -169,6 +169,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_localaccounts_globalpolicy.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy.py
@@ -203,6 +203,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_localaccounts_globalpolicy_info.py
+++ b/plugins/modules/appliance_localaccounts_globalpolicy_info.py
@@ -166,6 +166,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_localaccounts_info.py
+++ b/plugins/modules/appliance_localaccounts_info.py
@@ -200,6 +200,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_monitoring_info.py
+++ b/plugins/modules/appliance_monitoring_info.py
@@ -996,6 +996,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -256,6 +256,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_networking.py
+++ b/plugins/modules/appliance_networking.py
@@ -194,6 +194,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_networking_info.py
+++ b/plugins/modules/appliance_networking_info.py
@@ -190,6 +190,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_networking_interfaces_info.py
+++ b/plugins/modules/appliance_networking_interfaces_info.py
@@ -203,6 +203,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_networking_interfaces_ipv4.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4.py
@@ -245,6 +245,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_networking_interfaces_ipv4_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv4_info.py
@@ -177,6 +177,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_networking_interfaces_ipv6.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6.py
@@ -239,6 +239,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_networking_interfaces_ipv6_info.py
+++ b/plugins/modules/appliance_networking_interfaces_ipv6_info.py
@@ -181,6 +181,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_services.py
+++ b/plugins/modules/appliance_services.py
@@ -204,6 +204,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_services_info.py
+++ b/plugins/modules/appliance_services_info.py
@@ -182,6 +182,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_shutdown.py
+++ b/plugins/modules/appliance_shutdown.py
@@ -217,6 +217,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_shutdown_info.py
+++ b/plugins/modules/appliance_shutdown_info.py
@@ -170,6 +170,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_system_storage.py
+++ b/plugins/modules/appliance_system_storage.py
@@ -190,6 +190,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_system_storage_info.py
+++ b/plugins/modules/appliance_system_storage_info.py
@@ -163,6 +163,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_system_time_info.py
+++ b/plugins/modules/appliance_system_time_info.py
@@ -167,6 +167,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_system_version_info.py
+++ b/plugins/modules/appliance_system_version_info.py
@@ -170,6 +170,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_update_info.py
+++ b/plugins/modules/appliance_update_info.py
@@ -165,6 +165,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -217,6 +217,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/appliance_vmon_service_info.py
+++ b/plugins/modules/appliance_vmon_service_info.py
@@ -551,6 +551,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/content_configuration.py
+++ b/plugins/modules/content_configuration.py
@@ -244,6 +244,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/content_configuration_info.py
+++ b/plugins/modules/content_configuration_info.py
@@ -167,6 +167,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/content_library_info.py
+++ b/plugins/modules/content_library_info.py
@@ -165,6 +165,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/content_library_subscriptions_info.py
+++ b/plugins/modules/content_library_subscriptions_info.py
@@ -179,6 +179,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/content_locallibrary_info.py
+++ b/plugins/modules/content_locallibrary_info.py
@@ -401,6 +401,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/content_subscribedlibrary_info.py
+++ b/plugins/modules/content_subscribedlibrary_info.py
@@ -191,6 +191,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_datacenter.py
+++ b/plugins/modules/vcenter_datacenter.py
@@ -257,6 +257,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_datacenter_info.py
+++ b/plugins/modules/vcenter_datacenter_info.py
@@ -228,6 +228,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_datastore_info.py
+++ b/plugins/modules/vcenter_datastore_info.py
@@ -265,6 +265,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_folder_info.py
+++ b/plugins/modules/vcenter_folder_info.py
@@ -258,6 +258,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_host_info.py
+++ b/plugins/modules/vcenter_host_info.py
@@ -264,6 +264,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_network_info.py
+++ b/plugins/modules/vcenter_network_info.py
@@ -255,6 +255,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_ovf_libraryitem.py
+++ b/plugins/modules/vcenter_ovf_libraryitem.py
@@ -466,6 +466,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_resourcepool.py
+++ b/plugins/modules/vcenter_resourcepool.py
@@ -363,6 +363,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_resourcepool_info.py
+++ b/plugins/modules/vcenter_resourcepool_info.py
@@ -285,6 +285,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_storage_policies_info.py
+++ b/plugins/modules/vcenter_storage_policies_info.py
@@ -212,6 +212,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_guest_filesystem_directories.py
+++ b/plugins/modules/vcenter_vm_guest_filesystem_directories.py
@@ -332,6 +332,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_guest_identity_info.py
+++ b/plugins/modules/vcenter_vm_guest_identity_info.py
@@ -190,6 +190,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
+++ b/plugins/modules/vcenter_vm_guest_localfilesystem_info.py
@@ -192,6 +192,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_guest_networking_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_info.py
@@ -193,6 +193,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_guest_networking_routes_info.py
+++ b/plugins/modules/vcenter_vm_guest_networking_routes_info.py
@@ -184,6 +184,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_guest_operations_info.py
+++ b/plugins/modules/vcenter_vm_guest_operations_info.py
@@ -162,6 +162,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_guest_power_info.py
+++ b/plugins/modules/vcenter_vm_guest_power_info.py
@@ -206,6 +206,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware.py
+++ b/plugins/modules/vcenter_vm_hardware.py
@@ -312,6 +312,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_sata_info.py
@@ -212,6 +212,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
+++ b/plugins/modules/vcenter_vm_hardware_adapter_scsi_info.py
@@ -200,6 +200,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_boot.py
+++ b/plugins/modules/vcenter_vm_hardware_boot.py
@@ -270,6 +270,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_boot_device.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device.py
@@ -231,6 +231,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_boot_device_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_device_info.py
@@ -190,6 +190,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_boot_info.py
+++ b/plugins/modules/vcenter_vm_hardware_boot_info.py
@@ -187,6 +187,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_cdrom_info.py
+++ b/plugins/modules/vcenter_vm_hardware_cdrom_info.py
@@ -199,6 +199,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_disk_info.py
+++ b/plugins/modules/vcenter_vm_hardware_disk_info.py
@@ -219,6 +219,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_ethernet_info.py
+++ b/plugins/modules/vcenter_vm_hardware_ethernet_info.py
@@ -204,6 +204,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_floppy.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy.py
@@ -291,6 +291,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_floppy_info.py
+++ b/plugins/modules/vcenter_vm_hardware_floppy_info.py
@@ -199,6 +199,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_info.py
+++ b/plugins/modules/vcenter_vm_hardware_info.py
@@ -181,6 +181,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_parallel.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel.py
@@ -283,6 +283,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_parallel_info.py
+++ b/plugins/modules/vcenter_vm_hardware_parallel_info.py
@@ -199,6 +199,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_serial.py
+++ b/plugins/modules/vcenter_vm_hardware_serial.py
@@ -361,6 +361,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_hardware_serial_info.py
+++ b/plugins/modules/vcenter_vm_hardware_serial_info.py
@@ -219,6 +219,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_info.py
+++ b/plugins/modules/vcenter_vm_info.py
@@ -428,6 +428,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_power_info.py
+++ b/plugins/modules/vcenter_vm_power_info.py
@@ -184,6 +184,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_storage_policy.py
+++ b/plugins/modules/vcenter_vm_storage_policy.py
@@ -242,6 +242,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_storage_policy_compliance.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance.py
@@ -196,6 +196,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_compliance_info.py
@@ -192,6 +192,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_storage_policy_info.py
+++ b/plugins/modules/vcenter_vm_storage_policy_info.py
@@ -186,6 +186,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_tools.py
+++ b/plugins/modules/vcenter_vm_tools.py
@@ -252,6 +252,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_tools_info.py
+++ b/plugins/modules/vcenter_vm_tools_info.py
@@ -249,6 +249,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_tools_installer.py
+++ b/plugins/modules/vcenter_vm_tools_installer.py
@@ -230,6 +230,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vm_tools_installer_info.py
+++ b/plugins/modules/vcenter_vm_tools_installer_info.py
@@ -205,6 +205,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],

--- a/plugins/modules/vcenter_vmtemplate_libraryitems.py
+++ b/plugins/modules/vcenter_vmtemplate_libraryitems.py
@@ -546,6 +546,10 @@ async def main():
         module.fail_json("vcenter_username cannot be empty")
     if not module.params["vcenter_password"]:
         module.fail_json("vcenter_password cannot be empty")
+    if os.getenv("VMWARE_ENABLE_TURBO") is not None:
+        module.warn(
+            "VMWARE_ENABLE_TURBO is deprecated and will be removed in vmware.vmware_rest 5.0.0"
+        )
     try:
         session = await open_session(
             vcenter_hostname=module.params["vcenter_hostname"],


### PR DESCRIPTION
##### SUMMARY
`cloud.common` doesn't support ansible-core 2.20, and it doesn't look like anyone is working on this. Actually, not supporting current ansible-core versions has been the reason to remove it from the Ansible Community Package (ansible-community/ansible-build-data#593).

We've made `cloud.common` optional in #600 but I think it's time to get rid of this collection completely by now. But in order to do this, we have to deprecate turbo mode / VMWARE_ENABLE_TURBO because enabling this also means using `cloud.common`.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
Lots, probably all.

##### ADDITIONAL INFORMATION
#637