### PR TITLE
CI: Use actions/checkout@v6

### DIFF
--- a/.github/workflows/eco-vcenter-ci.yml
+++ b/.github/workflows/eco-vcenter-ci.yml
@@ -24,7 +24,7 @@ jobs:
           sudo apt-get install podman
 
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha }}
 

--- a/changelogs/fragments/643-CI.yml
+++ b/changelogs/fragments/643-CI.yml
@@ -1,0 +1,5 @@
+trivial:
+  - Replace deprecated ``actions/checkout@v4`` with ``actions/checkout@v6``
+    (https://github.com/ansible-collections/vmware.vmware_rest/pull/643).
+  - Fix some linting errors
+    (https://github.com/ansible-collections/vmware.vmware_rest/pull/643).

--- a/plugins/modules/appliance_monitoring_query.py
+++ b/plugins/modules/appliance_monitoring_query.py
@@ -303,7 +303,9 @@ async def _query(params, session):
         "https://{vcenter_hostname}"
         # aa
         "/api/appliance/monitoring/query"
-    ).format(**params) + gen_args(params, _in_query_parameters)
+    ).format(
+        **params
+    ) + gen_args(params, _in_query_parameters)
     async with session.get(_url, json=payload, **session_timeout(params)) as resp:
         try:
             if resp.headers["Content-Type"] == "application/json":

--- a/plugins/modules/appliance_ntp.py
+++ b/plugins/modules/appliance_ntp.py
@@ -295,7 +295,9 @@ async def _test(params, session):
         "https://{vcenter_hostname}"
         # aa
         "/api/appliance/ntp?action=test"
-    ).format(**params) + gen_args(params, _in_query_parameters)
+    ).format(
+        **params
+    ) + gen_args(params, _in_query_parameters)
     async with session.post(_url, json=payload, **session_timeout(params)) as resp:
         try:
             if resp.headers["Content-Type"] == "application/json":

--- a/plugins/modules/appliance_vmon_service.py
+++ b/plugins/modules/appliance_vmon_service.py
@@ -274,7 +274,9 @@ async def _list_details(params, session):
         "https://{vcenter_hostname}"
         # aa
         "/rest/appliance/vmon/service"
-    ).format(**params) + gen_args(params, _in_query_parameters)
+    ).format(
+        **params
+    ) + gen_args(params, _in_query_parameters)
     async with session.get(_url, json=payload, **session_timeout(params)) as resp:
         try:
             if resp.headers["Content-Type"] == "application/json":

--- a/plugins/modules/vcenter_vm.py
+++ b/plugins/modules/vcenter_vm.py
@@ -1970,7 +1970,9 @@ async def _register(params, session):
         "https://{vcenter_hostname}"
         # aa
         "/api/vcenter/vm?action=register"
-    ).format(**params) + gen_args(params, _in_query_parameters)
+    ).format(
+        **params
+    ) + gen_args(params, _in_query_parameters)
     async with session.post(_url, json=payload, **session_timeout(params)) as resp:
         try:
             if resp.headers["Content-Type"] == "application/json":


### PR DESCRIPTION
I see this warning in the [CI](https://github.com/ansible-collections/vmware.vmware_rest/actions/runs/25819153995):

> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/checkout@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Node.js 20 will be removed from the runner on September 16th, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/

Let's try to update to a newer version of `actions/checkout`.

##### ADDITIONAL INFORMATION
ansible-collections/vmware.vmware#363
ansible-collections/community.vmware#2553