### PR TITLE
Chore/fix integration

### DIFF
--- a/.agents/skills/generate-integration-tests/SKILL.md
+++ b/.agents/skills/generate-integration-tests/SKILL.md
@@ -282,9 +282,19 @@ Without running tests, these critical bugs would have shipped!
 
 ### MockServer State Management
 
-The MockServer maintains the current API state. Tests must explicitly load the appropriate mock spec before each operation:
+The MockServer maintains the current API state. Tests must explicitly load the appropriate mock spec before each operation.
+
+**IMPORTANT — Reset Before Each Expectation Load**: MockServer 7.x treats `PUT /mockserver/openapi` as **additive** — each call adds expectations without clearing previous ones. This means expectations from earlier test steps bleed into later ones, causing non-deterministic failures (e.g., an "empty list" expectation competing with a "resource exists" expectation).
+
+**You must reset MockServer before every expectation load** (except the first one in `main.yml`, since MockServer has just started). Use the `prepare_simulator` role with `prepare_simulator_reset: true`:
 
 ```yaml
+- name: Reset before <context> expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for <state>
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -297,10 +307,13 @@ The MockServer maintains the current API state. Tests must explicitly load the a
         <OperationId>_<operation>: "<response_code>"
 ```
 
+The reset clears all expectations and re-establishes the session authentication expectation (required for modules to connect).
+
 **Common patterns**:
 - Load `default.json` before testing creation of non-existent resource
 - Load `created.json` before testing idempotent operations
 - Switch specs to simulate state changes
+- Always reset before switching specs to avoid expectation conflicts
 
 ### Assertion Patterns
 
@@ -462,6 +475,7 @@ The mock generator automatically determines these from the module's `LIST_PATH`.
 
 ### Tests fail on idempotency check
 - Mock spec not switched to `created.json` state
+- MockServer expectations accumulated from prior steps (add reset before expectation load)
 - Module may have actual bug (report to user)
 
 ### Check mode test fails
@@ -473,6 +487,11 @@ The mock generator automatically determines these from the module's `LIST_PATH`.
 - The mock generator creates `updated.json` identical to `created.json` as a baseline
 - You must manually edit it to reflect your test's UPDATE values (see Step 2.5)
 - Compare GET response values with what your UPDATE operation sends
+
+### Tests fail with unexpected responses or wrong data
+- MockServer expectations from previous test steps may still be active
+- Add a `prepare_simulator` reset before each `Load API spec expectations` task
+- The only exception is the first load in `main.yml` (MockServer just started)
 
 ## Example: Complete Test Generation
 

--- a/.agents/skills/generate-integration-tests/reference/create_tests_pattern.yml
+++ b/.agents/skills/generate-integration-tests/reference/create_tests_pattern.yml
@@ -11,6 +11,12 @@
 # ============================================================
 
 # Test 1: Initial creation
+- name: Reset before create expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for create
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -37,6 +43,12 @@
       - create_result.id == '<resource_id>'
 
 # Test 2: Idempotent creation
+- name: Reset before created state expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for created state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -63,6 +75,12 @@
       - create_again.id == '<resource_id>'
 
 # Test 3: Check mode when resource doesn't exist
+- name: Reset before check mode expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec for deleted state (for check mode test)
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -88,6 +106,12 @@
       - create_check.changed
 
 # Test 4: Check mode when resource exists
+- name: Reset before idempotent check mode expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec back to created state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"

--- a/.agents/skills/generate-integration-tests/reference/delete_tests_pattern.yml
+++ b/.agents/skills/generate-integration-tests/reference/delete_tests_pattern.yml
@@ -12,6 +12,12 @@
 # ============================================================
 
 # Test 1: Delete by ID
+- name: Reset before delete expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for delete
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -37,6 +43,12 @@
       - delete_result.id == '<resource_id>'
 
 # Test 2: Idempotent deletion
+- name: Reset before empty state expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for empty state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -61,6 +73,12 @@
       - not delete_again.changed
 
 # Test 3: Check mode when resource exists
+- name: Reset before check mode delete expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec for resource exists
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -85,6 +103,12 @@
       - delete_check.changed
 
 # Test 4: Check mode when resource doesn't exist
+- name: Reset before idempotent check mode delete expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec for empty state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -109,6 +133,12 @@
       - not delete_check_idem.changed
 
 # Test 5: Delete by name (if name-based lookup is supported)
+- name: Reset before delete by name expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec with resource present for name-based delete
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"

--- a/.agents/skills/generate-integration-tests/reference/info_tests_pattern.yml
+++ b/.agents/skills/generate-integration-tests/reference/info_tests_pattern.yml
@@ -24,6 +24,12 @@
       - list_empty.<resource_plural> | length == 0
 
 # Test 2: Get by ID
+- name: Reset before get expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for get
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -51,6 +57,12 @@
       # Add more field checks as appropriate
 
 # Test 3: List multiple items
+- name: Reset before multiple list expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for multiple
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"

--- a/.agents/skills/generate-integration-tests/reference/update_tests_pattern.yml
+++ b/.agents/skills/generate-integration-tests/reference/update_tests_pattern.yml
@@ -12,6 +12,12 @@
 # ============================================================
 
 # Test 1: Initial update
+- name: Reset before update expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for update
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -39,6 +45,12 @@
       - update_result.id == '<resource_id>'
 
 # Test 2: Idempotent update
+- name: Reset before updated state expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for updated state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -66,6 +78,12 @@
       - update_again.id == '<resource_id>'
 
 # Test 3: Check mode when update would occur
+- name: Reset before check mode update expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec for original state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -91,6 +109,12 @@
       - update_check.changed
 
 # Test 4: Check mode when no update needed
+- name: Reset before idempotent check mode update expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec for updated state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"

--- a/.github/workflows/certification_check.yml
+++ b/.github/workflows/certification_check.yml
@@ -34,7 +34,7 @@ concurrency:
 # for each affected version of ansible-core (for example, `tests/sanity/ignore-2.18.txt`) and add corresponding entries.
 jobs:
   certification_check:
-    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v3.0.1 # zizmor: ignore[unpinned-uses]
+    uses: ansible-collections/partner-certification-checker/.github/workflows/certification-reusable.yml@v3.0.0 # zizmor: ignore[unpinned-uses]
     # If the minimal Ansible Core version your collection supports Ansible
     # is greater than 2.16.0, specify it below.
     # You might also have to specify Python version supported by that version,

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -113,7 +113,7 @@ jobs:
         run: |
           set -euxo pipefail
           sudo apt-get update -y
-          sudo apt-get install -y --upgrade podman
+          sudo apt-get install -y --upgrade podman crun
 
       - name: Checkout repo
         uses: actions/checkout@v7

--- a/tests/integration/targets/prepare_simulator/defaults/main.yml
+++ b/tests/integration/targets/prepare_simulator/defaults/main.yml
@@ -1,5 +1,6 @@
 ---
 prepare_simulator_mock_api_spec_file_dir: ""
+prepare_simulator_reset: false
 mockserver_port: 1080
 mockserver_image: "mockserver/mockserver:latest"
 mockserver_container_name: "vmware_rest_mockserver"

--- a/tests/integration/targets/prepare_simulator/tasks/main.yml
+++ b/tests/integration/targets/prepare_simulator/tasks/main.yml
@@ -1,61 +1,66 @@
 ---
-# Ensure new volumes get mounted
-- name: Stop Mockserver container
-  containers.podman.podman_container:
-    name: "{{ mockserver_container_name }}"
-    state: stopped
-  failed_when: false
+- name: Start mockserver
+  when: not prepare_simulator_reset
+  block:
+    # Ensure new volumes get mounted
+    - name: Stop Mockserver container
+      containers.podman.podman_container:
+        name: "{{ mockserver_container_name }}"
+        state: stopped
+      failed_when: false
 
-- name: Start MockServer container
-  containers.podman.podman_container:
-    name: "{{ mockserver_container_name }}"
-    image: "{{ mockserver_image }}"
-    state: started
-    ports:
-      - "{{ mockserver_port }}:1080"
-    volumes:
-      - "{{ role_path }}/../{{ prepare_simulator_mock_api_spec_file_dir }}:/mockserver_specs:ro,z"
-    env:
-      MOCKSERVER_WATCH_INITIALIZATION_JSON: "false"
-      MOCKSERVER_INITIALIZATION_JSON_PATH: "/mockserver_specs"
-      MOCKSERVER_LOG_LEVEL: "INFO"
-  register: mockserver_container
+    - name: Start MockServer container
+      containers.podman.podman_container:
+        name: "{{ mockserver_container_name }}"
+        image: "{{ mockserver_image }}"
+        state: started
+        ports:
+          - "{{ mockserver_port }}:1080"
+        volumes:
+          - "{{ role_path }}/../{{ prepare_simulator_mock_api_spec_file_dir }}:/mockserver_specs:ro,z"
+        env:
+          MOCKSERVER_LOG_LEVEL: "INFO"
+      register: mockserver_container
 
-- name: Set environment auth vars for MockServer
-  ansible.builtin.set_fact:
-    mockserver_url: http://localhost:{{ mockserver_port }}
-    environment_auth_vars:
-      VMWARE_HOST: "localhost"
-      VMWARE_USER: "mockuser"
-      VMWARE_PASSWORD: "mockpassword"
-      VMWARE_VALIDATE_CERTS: "False"
-      VMWARE_PORT: "{{ mockserver_port }}"
+    - name: Set environment auth vars for MockServer
+      ansible.builtin.set_fact:
+        mockserver_url: http://localhost:{{ mockserver_port }}
+        environment_auth_vars:
+          VMWARE_HOST: "localhost"
+          VMWARE_USER: "mockuser"
+          VMWARE_PASSWORD: "mockpassword"
+          VMWARE_VALIDATE_CERTS: "False"
+          VMWARE_PORT: "{{ mockserver_port }}"
 
-- name: Wait for MockServer to be ready
-  ansible.builtin.uri:
-    url: "{{ mockserver_url }}/mockserver/status"
-    method: PUT
-    status_code: [200]
-  retries: 30
-  delay: 2
-  register: mockserver_status
-  until: mockserver_status is succeeded
+    - name: Wait for MockServer to be ready
+      ansible.builtin.uri:
+        url: "{{ mockserver_url }}/mockserver/status"
+        method: PUT
+        status_code: [200]
+      retries: 30
+      delay: 2
+      register: mockserver_status
+      until: mockserver_status is succeeded
 
-- name: Set up expectation for session authentication
-  ansible.builtin.uri:
-    url: "{{ mockserver_url }}/mockserver/expectation"
-    method: PUT
-    status_code: [200, 201]
-    body_format: json
-    body:
-      id: session-auth
-      httpRequest:
-        method: POST
-        path: /rest/com/vmware/cis/session
-      httpResponse:
-        statusCode: 200
-        headers:
-          Content-Type:
-            - application/json
+    - name: Set up expectation for session authentication
+      ansible.builtin.uri:
+        url: "{{ mockserver_url }}/mockserver/expectation"
+        method: PUT
+        status_code: [200, 201]
+        body_format: json
         body:
-          value: mock-session-id
+          id: session-auth
+          httpRequest:
+            method: POST
+            path: /rest/com/vmware/cis/session
+          httpResponse:
+            statusCode: 200
+            headers:
+              Content-Type:
+                - application/json
+            body:
+              value: mock-session-id
+
+- name: Reset mockserver
+  ansible.builtin.include_tasks: reset_mockserver.yml
+  when: prepare_simulator_reset

--- a/tests/integration/targets/prepare_simulator/tasks/reset_mockserver.yml
+++ b/tests/integration/targets/prepare_simulator/tasks/reset_mockserver.yml
@@ -1,0 +1,25 @@
+---
+- name: Reset MockServer expectations
+  ansible.builtin.uri:
+    url: "{{ mockserver_url }}/mockserver/reset"
+    method: PUT
+    status_code: [200]
+
+- name: Re-establish session authentication
+  ansible.builtin.uri:
+    url: "{{ mockserver_url }}/mockserver/expectation"
+    method: PUT
+    status_code: [200, 201]
+    body_format: json
+    body:
+      id: session-auth
+      httpRequest:
+        method: POST
+        path: /rest/com/vmware/cis/session
+      httpResponse:
+        statusCode: 200
+        headers:
+          Content-Type:
+            - application/json
+        body:
+          value: mock-session-id

--- a/tests/integration/targets/vcenter_datacenter/tasks/create.yml
+++ b/tests/integration/targets/vcenter_datacenter/tasks/create.yml
@@ -2,6 +2,12 @@
 # ============================================================
 # CREATE DATACENTER TESTS
 # ============================================================
+- name: Reset before create expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for create
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -26,6 +32,12 @@
     that:
       - create_dc.changed
       - create_dc.id == 'datacenter-1001'
+
+- name: Reset before created state expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
 
 - name: Load API spec expectations for created state
   ansible.builtin.uri:
@@ -52,6 +64,12 @@
       - not create_dc_again.changed
       - create_dc_again.id == 'datacenter-1001'
 
+- name: Reset before check mode expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec for deleted state (for check mode test)
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -75,6 +93,12 @@
   ansible.builtin.assert:
     that:
       - create_dc_check.changed
+
+- name: Reset before idempotent check mode expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
 
 - name: Load API spec back to created state
   ansible.builtin.uri:

--- a/tests/integration/targets/vcenter_datacenter/tasks/delete.yml
+++ b/tests/integration/targets/vcenter_datacenter/tasks/delete.yml
@@ -2,6 +2,12 @@
 # ============================================================
 # DELETE DATACENTER TESTS
 # ============================================================
+- name: Reset before delete expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for delete
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -26,6 +32,12 @@
       - delete_dc.changed
       - delete_dc.id == 'datacenter-1001'
 
+- name: Reset before empty state expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for empty state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -48,6 +60,12 @@
   ansible.builtin.assert:
     that:
       - not delete_dc_again.changed
+
+- name: Reset before check mode delete expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
 
 - name: Load API spec for final delete test
   ansible.builtin.uri:
@@ -72,6 +90,12 @@
     that:
       - delete_dc_check.changed
 
+- name: Reset before idempotent check mode delete expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec for empty state
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -94,6 +118,12 @@
   ansible.builtin.assert:
     that:
       - not delete_dc_check_idem.changed
+
+- name: Reset before delete by name expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
 
 - name: Load API spec with datacenter present for final test
   ansible.builtin.uri:

--- a/tests/integration/targets/vcenter_datacenter/tasks/info.yml
+++ b/tests/integration/targets/vcenter_datacenter/tasks/info.yml
@@ -12,6 +12,12 @@
       - list_dc_info.info is defined
       - list_dc_info.info | length == 0
 
+- name: Reset before get expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
+
 - name: Load API spec expectations for get
   ansible.builtin.uri:
     url: "{{ mockserver_url }}/mockserver/openapi"
@@ -33,6 +39,12 @@
     that:
       - get_dc_id.value is defined
       - get_dc_id.value.name == 'my_datacenter'
+
+- name: Reset before multiple list expectations
+  ansible.builtin.include_role:
+    name: prepare_simulator
+  vars:
+    prepare_simulator_reset: true
 
 - name: Load API spec expectations for multiple
   ansible.builtin.uri:


### PR DESCRIPTION
##### SUMMARY
A newer version of the mock server used in integration tests changes how API expectations are merged. This change adds a step to reset expectations in between tests

##### ISSUE TYPE
- Bugfix Pull Request

